### PR TITLE
Fix load packages tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.17.0"
+          node-version: "18"
 
       - name: Install dependencies
         run: npm install

--- a/src/helpers/conformance/getCachePath.test.ts
+++ b/src/helpers/conformance/getCachePath.test.ts
@@ -1,0 +1,67 @@
+
+/**
+ * © Copyright Outburn Ltd. 2022-2023 All Rights Reserved
+ *   Project name: FUME
+ */
+
+import os from 'os';
+import path from 'path';
+import { getCachePath, getCachedPackageDirs } from './getCachePath';
+import { test } from '@jest/globals';
+import * as fs from 'fs';
+jest.mock('fs');
+
+describe('Cache paths', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('Creates the getCachePath folder if it does not exist', async () => {
+    let counter = 0;
+    (fs.existsSync as jest.Mock).mockImplementation(() => {
+      if (counter === 0) {
+        counter++;
+        return false;
+      }
+      return true;
+    });
+    (fs.mkdirSync as jest.Mock).mockReturnValue(true);
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+    await getCachePath();
+    expect(fs.mkdirSync).toHaveBeenCalledTimes(1);
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(os.homedir(), '.fhir'), { recursive: true });
+  });
+
+  test('Doesnt create the cache folder if it exists', async () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.mkdirSync as jest.Mock).mockReturnValue(true);
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+    await getCachePath();
+    expect(fs.mkdirSync).toHaveBeenCalledTimes(0);
+  });
+
+  test('empty getCachedPackageDirs', async () => {
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+    const dirs = getCachedPackageDirs();
+    expect(dirs).toHaveLength(0);
+  });
+
+  test('getCachedPackageDirs with folders', async () => {
+    (fs.readdirSync as jest.Mock).mockReturnValue([{
+      isDirectory: () => true,
+      name: 'test'
+    }]);
+    const dirs = getCachedPackageDirs();
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0]).toBe('test');
+  });
+
+  test('getCachedPackageDirs with non folder', async () => {
+    (fs.readdirSync as jest.Mock).mockReturnValue([{
+      isDirectory: () => false,
+      name: 'test'
+    }]);
+    const dirs = getCachedPackageDirs();
+    expect(dirs).toHaveLength(0);
+  });
+});

--- a/src/helpers/conformance/getCachePath.ts
+++ b/src/helpers/conformance/getCachePath.ts
@@ -19,3 +19,7 @@ export const getCachedPackageDirs = () => {
   const cachePath = getCachePackagesPath();
   return fs.readdirSync(cachePath, { withFileTypes: true }).filter(entry => entry.isDirectory()).map(dir => dir.name);
 };
+
+export const getFumeIndexFilePath = () => {
+  return path.join(getCachePath(), 'fume.index.json');
+};

--- a/src/helpers/conformance/getCachePath.ts
+++ b/src/helpers/conformance/getCachePath.ts
@@ -1,0 +1,21 @@
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+export const getCachePath = (innerFolder = '') => {
+  const cachePath = path.join(os.homedir(), '.fhir', innerFolder);
+  if (!fs.existsSync(cachePath)) {
+    fs.mkdirSync(cachePath, { recursive: true });
+    console.log(`Directory '${cachePath}' created successfully.`);
+  }
+  return cachePath;
+};
+
+export const getCachePackagesPath = () => {
+  return getCachePath('packages');
+};
+
+export const getCachedPackageDirs = () => {
+  const cachePath = getCachePackagesPath();
+  return fs.readdirSync(cachePath, { withFileTypes: true }).filter(entry => entry.isDirectory()).map(dir => dir.name);
+};

--- a/src/helpers/conformance/loadFhirPackageIndex.test.ts
+++ b/src/helpers/conformance/loadFhirPackageIndex.test.ts
@@ -18,7 +18,10 @@ describe('loadFhirPackageIndex', () => {
 
   test('Creates the cache folder if it does not exist', async () => {
     let counter = 0;
-    (fs.existsSync as jest.Mock).mockImplementation(() => {
+    (fs.existsSync as jest.Mock).mockImplementation((name: string) => {
+      if (name.includes('fume.index.json')) {
+        return false;
+      }
       if (counter === 0) {
         counter++;
         return false;
@@ -33,7 +36,12 @@ describe('loadFhirPackageIndex', () => {
   });
 
   test('Doesnt create the cache folder if it exists', async () => {
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.existsSync as jest.Mock).mockImplementation((name: string) => {
+      if (name.includes('fume.index.json')) {
+        return false;
+      }
+      return true;
+    });
     (fs.mkdirSync as jest.Mock).mockReturnValue(true);
     (fs.readdirSync as jest.Mock).mockReturnValue([]);
     await loadFhirPackageIndex();

--- a/src/helpers/conformance/loadFhirPackageIndex.ts
+++ b/src/helpers/conformance/loadFhirPackageIndex.ts
@@ -5,7 +5,7 @@ import { isNumeric } from '../stringFunctions';
 import path from 'path';
 import fs from 'fs-extra';
 import { getLogger } from '../logger';
-import { getCachePackagesPath, getCachePath, getCachedPackageDirs } from './getCachePath';
+import { getCachePackagesPath, getCachedPackageDirs, getFumeIndexFilePath } from './getCachePath';
 
 export type IFhirPackage = any;
 export type IFhirPackageIndex = Record<string, IFhirPackage>;
@@ -85,8 +85,7 @@ const buildFhirCacheIndex = async () => {
 };
 
 const parseFhirPackageIndex = async (): Promise<IFhirPackageIndex> => {
-  const cachePath = getCachePath();
-  const fumeIndexPath = path.join(cachePath, 'fume.index.json');
+  const fumeIndexPath = getFumeIndexFilePath();
   if (fs.existsSync(fumeIndexPath)) {
     getLogger().info(`Found global package index file at ${fumeIndexPath}`);
     const dirList: string[] = getCachedPackageDirs();

--- a/src/helpers/conformance/loadFhirPackageIndex.ts
+++ b/src/helpers/conformance/loadFhirPackageIndex.ts
@@ -2,23 +2,14 @@
 import expressions from '../jsonataExpression';
 import { omitKeys } from '../objectFunctions';
 import { isNumeric } from '../stringFunctions';
-import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { getLogger } from '../logger';
+import { getCachePackagesPath, getCachePath, getCachedPackageDirs } from './getCachePath';
 
 export type IFhirPackage = any;
 export type IFhirPackageIndex = Record<string, IFhirPackage>;
 let fhirPackageIndex: IFhirPackageIndex = {};
-
-const getCachePath = () => {
-  const cachePath = path.join(os.homedir(), '.fhir');
-  if (!fs.existsSync(cachePath)) {
-    fs.mkdirSync(cachePath, { recursive: true });
-    console.log(`Directory '${cachePath}' created successfully.`);
-  }
-  return cachePath;
-};
 
 const createPackageIndexFile = (packagePath: string) => {
   try {
@@ -51,8 +42,8 @@ const createPackageIndexFile = (packagePath: string) => {
 
 const buildFhirCacheIndex = async () => {
   getLogger().info('Building global package index (this might take some time...)');
-  const cachePath = path.join(getCachePath(), 'packages');
-  const dirList: string[] = fs.readdirSync(cachePath, { withFileTypes: true }).filter(entry => entry.isDirectory()).map(dir => dir.name);
+  const cachePath = getCachePackagesPath();
+  const dirList: string[] = getCachedPackageDirs();
   getLogger().info(`FHIR Packages found in global cache: ${dirList.join(', ')}`);
   const packageIndexArray = dirList.map(pack => {
     if (fs.existsSync(path.join(cachePath, pack, 'package', 'package.json'))) {
@@ -98,7 +89,7 @@ const parseFhirPackageIndex = async (): Promise<IFhirPackageIndex> => {
   const fumeIndexPath = path.join(cachePath, 'fume.index.json');
   if (fs.existsSync(fumeIndexPath)) {
     getLogger().info(`Found global package index file at ${fumeIndexPath}`);
-    const dirList: string[] = fs.readdirSync(path.join(cachePath, 'packages'), { withFileTypes: true }).filter(entry => entry.isDirectory()).map(dir => dir.name);
+    const dirList: string[] = getCachedPackageDirs();
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const currentIndex = require(fumeIndexPath);
     const currentPackages = await expressions.extractCurrentPackagesFromIndex.evaluate(currentIndex);

--- a/src/helpers/conformance/loadPackages.test.ts
+++ b/src/helpers/conformance/loadPackages.test.ts
@@ -8,16 +8,24 @@ import { test } from '@jest/globals';
 import mockAxios from 'jest-mock-axios';
 
 import * as fpl from 'fhir-package-loader';
+
+import * as cached from './getCachePath';
 jest.mock('fhir-package-loader');
 const mockFpl = jest.mocked(fpl, { shallow: true });
+const mockCached = jest.mocked(cached, { shallow: true });
 
 describe('loadPackages', () => {
+  beforeEach(() => {
+    mockCached.getCachedPackageDirs = jest.fn().mockReturnValue([]);
+    mockCached.getCachePackagesPath = jest.fn().mockReturnValue('cachePath');
+  });
+
   afterEach(() => {
     mockAxios.reset();
     jest.resetAllMocks();
   });
 
-  test('Load empty list of packages asa', async () => {
+  test('Load empty list of packages', async () => {
     await loadPackages([], [], []);
     mockFpl.fpl.mockResolvedValue({} as any);
     expect(mockFpl.fpl).toHaveBeenCalledTimes(1);
@@ -61,5 +69,8 @@ describe('loadPackages', () => {
     mockFpl.fpl.mockResolvedValue({} as any);
     expect(mockFpl.fpl).toHaveBeenCalledTimes(1);
     expect(mockFpl.fpl).toHaveBeenCalledWith(['il.core.fhir.r4@0.11.0'], { log: expect.any(Function) });
+  });
+
+  test.skip('Loads package.json cached package', async () => {
   });
 });

--- a/src/helpers/conformance/loadPackages.test.ts
+++ b/src/helpers/conformance/loadPackages.test.ts
@@ -17,7 +17,7 @@ describe('loadPackages', () => {
     jest.resetAllMocks();
   });
 
-  test('Load empty list of packages', async () => {
+  test('Load empty list of packages asa', async () => {
     await loadPackages([], [], []);
     mockFpl.fpl.mockResolvedValue({} as any);
     expect(mockFpl.fpl).toHaveBeenCalledTimes(1);

--- a/src/helpers/conformance/loadPackages.ts
+++ b/src/helpers/conformance/loadPackages.ts
@@ -1,11 +1,11 @@
 
-import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { fpl } from 'fhir-package-loader';
 import { getLogger } from '../logger';
 import axios from 'axios';
 import _ from 'lodash';
+import { getCachePackagesPath, getCachedPackageDirs } from './getCachePath';
 
 export const loadPackage = async (fhirPackage: string | string[]) => {
   try {
@@ -45,8 +45,8 @@ export const loadPackages = async (packages: string[], mustPackages: string[], e
   await loadPackage(packagesToLoad.filter(Boolean));
 
   // Retrieving the list of the directories in the .fhir directory.
-  const cachePath = path.join(os.homedir(), '.fhir', 'packages');
-  const dirList: string[] = fs.readdirSync(cachePath, { withFileTypes: true }).filter(entry => entry.isDirectory()).map(dir => dir.name);
+  const cachePath = getCachePackagesPath();
+  const dirList: string[] = getCachedPackageDirs();
 
   // For each directory, searching for it's package.json and getting it's dependencies for loading.
   await Promise.all(dirList.map(async p => {


### PR DESCRIPTION
Load packages unit tests were failing when there was no .fhir folder 
 - Added mocks for `fs` access
