### PR TITLE
fix: expose getConfig on FumeServer

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import { fhirVersionToMinor } from './helpers/fhirFunctions/fhirVersionToMinor';
 const additionalBindings: Record<string, IAppBinding> = {}; // additional functions to bind when running transformations
 let serverConfig: IConfig = { ...defaultConfig };
 
-const setServerConfig = (config: IConfig) => {
+const setServerConfig = <ConfigType extends IConfig>(config: ConfigType) => {
   let fhirServerBase: string = config.FHIR_SERVER_BASE;
   let isStatelessMode: boolean = config.SERVER_STATELESS;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ import type {
 import { getCache, IAppCacheKeys, initCache, InitCacheConfig } from './helpers/cache';
 import { FhirClient, setFhirClient } from './helpers/fhirServer';
 
-export class FumeServer implements IFumeServer {
+export class FumeServer<ConfigType extends IConfig> implements IFumeServer<ConfigType> {
   private readonly app: express.Application;
   private server?: Server;
   /**
@@ -53,8 +53,8 @@ export class FumeServer implements IFumeServer {
     }
   }
 
-  public async warmUp (serverOptions: IConfig | undefined = undefined): Promise<void> {
-    const options: IConfig = serverOptions ?? defaultConfig;
+  public async warmUp (serverOptions?: ConfigType | undefined): Promise<void> {
+    const options = serverOptions ?? defaultConfig;
     this.logger.info('FUME initializing...');
     config.setServerConfig(options);
     const serverConfig: IConfig = config.getServerConfig();
@@ -167,6 +167,14 @@ export class FumeServer implements IFumeServer {
    */
   public getCache () {
     return getCache();
+  }
+
+  /**
+   *
+   * @returns config
+   */
+  public getConfig () {
+    return config.getServerConfig() as ConfigType;
   }
 
   /**

--- a/src/types/FumeServer.ts
+++ b/src/types/FumeServer.ts
@@ -1,6 +1,5 @@
 import { Application } from 'express';
 import { ILogger } from './Logger';
-import { IConfig } from './Config';
 import { ICache } from './Cache';
 import { IFhirClient } from './FhirClient';
 import { IAppCache, IAppCacheKeys } from '../helpers/cache/cacheTypes';
@@ -9,9 +8,9 @@ import { IFhirPackageIndex } from '../helpers/conformance/loadFhirPackageIndex';
 export type ICacheClass = new <T>(options: Record<string, any>) => ICache<T>;
 export type IAppBinding = any;
 
-export interface IFumeServer {
+export interface IFumeServer<ConfigType> {
   registerLogger: (logger: ILogger) => void
-  registerFhirClient: (fhitClient: IFhirClient) => void
+  registerFhirClient: (fhirClient: IFhirClient) => void
   getFhirClient: () => IFhirClient
   registerCacheClass: (
     CacheClass: ICacheClass,
@@ -20,8 +19,9 @@ export interface IFumeServer {
   ) => void
   registerBinding: (key: string, binding: IAppBinding) => void
   getCache: () => IAppCache
+  getConfig: () => ConfigType
   getExpressApp: () => Application
-  warmUp: (serverOptions: IConfig | undefined) => Promise<void>
+  warmUp: (serverOptions: ConfigType | undefined) => Promise<void>
   shutDown: () => Promise<void>
 
   getFhirPackageIndex: () => IFhirPackageIndex


### PR DESCRIPTION
- Add generic config types to `FumeServer` to support extended config
- Expose a `fumeServer.getConfig()` method