### PR TITLE
fix: register not found route during warm up to allow consumers to extend server routes

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,13 +6,14 @@
 import express from 'express';
 import mapping from './mapping';
 import root from './root';
+import notFound from './notFound';
 
 const routes = express.Router();
 
 routes.use('/Mapping/', mapping);
 routes.use('/', root);
-routes.use((_req, res) => {
-  res.status(404).json({ message: 'not found' });
-});
 
-export default routes;
+export {
+  routes,
+  notFound
+};

--- a/src/routes/notFound.ts
+++ b/src/routes/notFound.ts
@@ -1,0 +1,10 @@
+
+import express from 'express';
+
+const notFound = express.Router();
+
+notFound.use((_req, res, next) => {
+  res.status(404).json({ message: 'not found' });
+});
+
+export default notFound;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import defaultConfig from './serverConfig';
 import config from './config';
-import routes from './routes';
+import { routes, notFound } from './routes';
 import { getLogger, setLogger } from './helpers/logger';
 import conformance from './helpers/conformance';
 import { transform } from './helpers/jsonataFunctions';
@@ -53,6 +53,12 @@ export class FumeServer<ConfigType extends IConfig> implements IFumeServer<Confi
     }
   }
 
+  /**
+   * Start the server
+   * Any extensions to the server should be done before calling this method
+   * i.e. registering alternative logger, cache class, fhir client and express routes.
+   * @param serverOptions
+   */
   public async warmUp (serverOptions?: ConfigType | undefined): Promise<void> {
     const options = serverOptions ?? defaultConfig;
     this.logger.info('FUME initializing...');
@@ -101,6 +107,11 @@ export class FumeServer<ConfigType extends IConfig> implements IFumeServer<Confi
         this.logger.info('Successfully loaded cache');
       }
     };
+
+    // catch any routes that are not found
+    // This allows consumers to extend the server with their own routes
+    // and still have a default 404 handler
+    this.app.use(notFound);
 
     this.server = this.app.listen(SERVER_PORT);
     this.logger.info(`FUME server is running on port ${SERVER_PORT}`);


### PR DESCRIPTION
We have a default "catch all" route that returns 404 if a route is not found.
However, registering it too early prevented `fume-enterprise` from adding additional routes.

This PR postpones the registration of the "catch all" route to the `warmUp` function, so that any routes registered before hand have a chance to run.