### PR TITLE
fix: better handling for unfound mappings

### DIFF
--- a/src/controllers/mapping.ts
+++ b/src/controllers/mapping.ts
@@ -13,16 +13,19 @@ import { parseCsv } from '../helpers/stringFunctions';
 const get = async (req: Request, res: Response) => {
   const logger = getLogger();
   try {
+    // get mapping id from route
     const mappingId: string = req.params.mappingId;
-    // get mapping expression from cache
+    // get mapping object from cache
     const mappingObj = getCache().compiledMappings.get(mappingId);
-    const mapping: string = mappingObj.expression;
-
-    if (mapping) {
+    if (mappingObj) {
+      // get expression from mapping object
+      const mapping: string = mappingObj.expression;
       res.set('Content-Type', 'application/vnd.outburn.fume');
       res.status(200).send(mapping);
     } else {
-      res.status(404).json({ message: 'not found' });
+      const message: string = `Mapping '${mappingId}' could not be found`;
+      logger.error(message);
+      res.status(404).json({ message });
     }
   } catch (error) {
     logger.error({ error });

--- a/tests/mappings/mapping.test.ts
+++ b/tests/mappings/mapping.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 
 describe('api tests', () => {
   test('get mapping that does not exist', async () => {
-    await request(globalThis.app).get('Mapping/1').expect(404);
+    await request(globalThis.app).get('/Mapping/11925e4e-6ac0-4a38-a817-9a1524c9e1aa').expect(404);
   });
 
   test('get mapping that does exist', async () => {


### PR DESCRIPTION
Mappings that were not found were not handled correctly and failed with a general 500 server error. Fixed this so this type of error will return 404, and only other unhandled issues will result in 500. Fixed the relevant integration test also.