### PR TITLE
test: add hapi.postgress.data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ node_modules
 .env
 .env.test
 .eslintcache
-
+hapi.postgress.data
 


### PR DESCRIPTION
added hapi.postgress.data folder generated by the integration test process to the .gitignore file