### PR TITLE
ci: notify fume-engine repo of a successful npm release

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -21,7 +21,8 @@ jobs:
                 ref: main
                 token: ${{ secrets.PAT }}
             
-            - name: Semantic Release
+            - id: semantic-release
+              name: Semantic Release
               uses: cycjimmy/semantic-release-action@v4
               with:
                 semantic_version: 21.1.1
@@ -33,3 +34,13 @@ jobs:
               env:
                 GITHUB_TOKEN: ${{ secrets.PAT }}
                 NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Notify release
+              if: steps.semantic-release.outputs.new_release_published == 'true'
+              run: |
+                curl -X POST  \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer ${{ secrets.PAT }}" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    https://api.github.com/repos/Outburn-IL/fume-engine/actions/workflows/repo-sync.yml/dispatches \
+                    -d '{"ref": "main"}'


### PR DESCRIPTION
Notifies the `fume-engine` repo of every successful publish