### PR TITLE
fix: remove all dynamic require()

### DIFF
--- a/src/helpers/conformance/conformance.ts
+++ b/src/helpers/conformance/conformance.ts
@@ -3,6 +3,8 @@
  *   Project name: FUME-COMMUNITY
  */
 
+import fs from 'fs-extra';
+
 import config from '../../config';
 import { getFhirClient } from '../fhirServer';
 import expressions from '../jsonataExpression';
@@ -26,8 +28,7 @@ export const getStructureDefinition = async (definitionId: string): Promise<any>
     throw (error);
   } else {
     const path: string = indexed;
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fullDef = require(path); // load file
+    const fullDef = JSON.parse(fs.readFileSync(path).toString()); // load file
     return fullDef;
   };
 };

--- a/src/helpers/jsonataFunctions/getStructureDefinition.ts
+++ b/src/helpers/jsonataFunctions/getStructureDefinition.ts
@@ -2,6 +2,8 @@
  * © Copyright Outburn Ltd. 2022-2024 All Rights Reserved
  *   Project name: FUME-COMMUNITY
  */
+import fs from 'fs-extra';
+
 import config from '../../config';
 import { getFhirPackageIndex } from '../conformance';
 import fhirFuncs from '../fhirFunctions';
@@ -34,9 +36,7 @@ export const getStructureDefinition = (definitionId: string): any => {
   try {
     const path: string = getStructureDefinitionPath(definitionId);
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fullDef = require(path); // load file
-    // getLogger().info(`Definition loaded: ${path}`);
+    const fullDef = JSON.parse(fs.readFileSync(path).toString()); // load file
     return fullDef;
   } catch (e) {
     return thrower.throwParseError(`A Problem occured while getting the structure definition of '${definitionId}'. The error is: ${e}`);


### PR DESCRIPTION
Replaced parameterized require() calls to fs.readFileSync, so the bundled code can work from within node's "Single Executable Applications"