### PR TITLE
V2.18.1

### DIFF
--- a/src/controllers/root.ts
+++ b/src/controllers/root.ts
@@ -5,6 +5,7 @@
 
 import type { Request, Response } from 'express';
 
+import { version as engineVersion } from '../../package.json';
 import config from '../config';
 import { getCache } from '../helpers/cache';
 import { recacheFromServer } from '../helpers/conformance';
@@ -16,14 +17,7 @@ import { toJsonataString } from '../helpers/parser/toJsonataString';
 const get = async (req: Request, res: Response) => {
   return res.status(200).json(
     {
-      public_sandbox: 'https://try.fume.health',
-      api_instructions: 'POST a JSON object to this endpoint, containing an input json value and a FUME expression.',
-      example_body: {
-        input: { values: ['value1', 'value2'] },
-        fume: 'values[1]',
-        contentType: 'application/json'
-      },
-      should_return: 'value2'
+      fume_version: `FUME Community v${engineVersion}`
     });
 };
 

--- a/src/helpers/conformance/ensurePackageInstalled.ts
+++ b/src/helpers/conformance/ensurePackageInstalled.ts
@@ -12,11 +12,11 @@ import * as tar from 'tar';
 import temp from 'temp';
 
 import config from '../../config';
-import { BaseResource } from '../../types/BaseResource';
 import { FileInPackageIndex } from '../../types/FileInPackageIndex';
 import { PackageIdentifier } from '../../types/PackageIdentifier';
 import { PackageIndex } from '../../types/PackageIndex';
 import { PackageManifest } from '../../types/PackageManifest';
+import { PackageResource } from '../../types/PackageResource';
 import { getLogger } from '../logger';
 import { getCachePackagesPath } from './getCachePath';
 
@@ -56,7 +56,7 @@ const generatePackageIndex = async (packageObject: PackageIdentifier): Promise<P
         file => file.endsWith('.json') && file !== 'package.json' && !file.endsWith('.index.json')
       ).map(
         async (file: string) => {
-          const content: BaseResource = JSON.parse(await fs.readFile(path.join(packagePath, 'package', file), { encoding: 'utf8' }));
+          const content: PackageResource = JSON.parse(await fs.readFile(path.join(packagePath, 'package', file), { encoding: 'utf8' }));
           const indexEntry: FileInPackageIndex = {
             filename: file,
             resourceType: content.resourceType,

--- a/src/helpers/fhirFunctions/reference.test.ts
+++ b/src/helpers/fhirFunctions/reference.test.ts
@@ -7,13 +7,7 @@ import { test } from '@jest/globals';
 import { reference } from './reference';
 
 describe('reference', () => {
-  test('returns undefined on anything but an object', async () => {
-    expect(reference('input')).toEqual(undefined);
-    expect(reference(['input'])).toEqual(undefined);
-    expect(reference({})).toEqual(undefined);
-  });
-
-  test('returns reference on valid object', async () => {
-    expect(reference({ hello: 'world' })).toEqual('urn:uuid:2248ee2f-a0aa-5ad9-9178-531f924bf00b');
+  test('returns reference on object with resourceType', async () => {
+    expect(reference({ resourceType: 'Patient' })).toEqual('urn:uuid:b22de17e-2144-5f20-9fba-966d21409f94');
   });
 });

--- a/src/helpers/fhirFunctions/reference.test.ts
+++ b/src/helpers/fhirFunctions/reference.test.ts
@@ -10,4 +10,7 @@ describe('reference', () => {
   test('returns reference on object with resourceType', async () => {
     expect(reference({ resourceType: 'Patient' })).toEqual('urn:uuid:b22de17e-2144-5f20-9fba-966d21409f94');
   });
+  test('returns undefined on undefined', async () => {
+    expect(reference(undefined)).toBeUndefined();
+  });
 });

--- a/src/helpers/fhirFunctions/reference.ts
+++ b/src/helpers/fhirFunctions/reference.ts
@@ -2,12 +2,15 @@
  * © Copyright Outburn Ltd. 2022-2024 All Rights Reserved
  *   Project name: FUME-COMMUNITY
  */
+import type { FhirResource } from '../../types/FhirResource';
 import { uuid } from '../stringFunctions';
+import thrower from '../thrower';
 
-export const reference = (resource: any): string | undefined => {
-  if (typeof resource === 'object' && Object.keys(resource).length > 0 && !Array.isArray(resource)) {
-    return 'urn:uuid:' + uuid(JSON.stringify(resource));
+export const reference = (resource: FhirResource | undefined): string | undefined => {
+  if (typeof resource === 'undefined') return undefined;
+  // Check that it is a FHIR resource
+  if (Array.isArray(resource) || Object.keys(resource).length === 0 || typeof resource !== 'object' || !resource?.resourceType) {
+    return thrower.throwRuntimeError('\'$reference()\' recieved a value that is not a FHIR resource');
   }
-
-  return undefined;
+  return 'urn:uuid:' + uuid(JSON.stringify(resource));
 };

--- a/src/helpers/fhirServer/client.ts
+++ b/src/helpers/fhirServer/client.ts
@@ -24,7 +24,8 @@ export class FhirClient implements IFhirClient {
 
   private authHeader (authType: string, username?: string, password?: string) {
     if (authType === 'BASIC' && username && password && username > '' && password > '') {
-      return `Basic ${btoa(username + ':' + password)}`;
+      const buff = Buffer.from(`${username}:${password}`, 'utf-8');
+      return `Basic ${buff.toString('base64')}`;
     } else {
       return undefined;
     }

--- a/src/helpers/jsonataFunctions/transform.ts
+++ b/src/helpers/jsonataFunctions/transform.ts
@@ -70,7 +70,6 @@ export const transform = async (input: any, expression: string, extraBindings: R
     bindings.__castToFhir = runtime.castToFhir;
     bindings.__flashMerge = runtime.flashMerge;
     bindings.wait = runtime.wait;
-    bindings.reference = fhirFuncs.reference;
     bindings.resourceId = fhirFuncs.resourceId;
     bindings.initCap = stringFuncs.initCap;
     bindings.isEmpty = objectFuncs.isEmpty;
@@ -126,6 +125,7 @@ export const transform = async (input: any, expression: string, extraBindings: R
     expr.registerFunction('startsWith', stringFuncs.startsWith, '<s-s:b>');
     expr.registerFunction('endsWith', stringFuncs.endsWith, '<s-s:b>');
     expr.registerFunction('isNumeric', stringFuncs.isNumeric, '<j-:b>');
+    expr.registerFunction('reference', fhirFuncs.reference, '<o-:s>');
     expr.registerFunction(
       'getStructureDefinition',
       (defId: string) => getStructureDefinition(defId, config.getFhirVersion(), conformance.getFhirPackageIndex(), getLogger()),

--- a/src/types/FhirResource.ts
+++ b/src/types/FhirResource.ts
@@ -6,8 +6,7 @@
 /**
  * A basic interface for a resource file in a package
  */
-export interface BaseResource {
-  id: string
+export interface FhirResource {
   resourceType: string
   [key: string]: any | any[]
 }

--- a/src/types/PackageResource.ts
+++ b/src/types/PackageResource.ts
@@ -1,0 +1,13 @@
+/**
+ * © Copyright Outburn Ltd. 2022-2024 All Rights Reserved
+ *   Project name: FUME-COMMUNITY
+ */
+
+/**
+ * A basic interface for a resource file in a package
+ */
+export interface PackageResource {
+  id: string
+  resourceType: string
+  [key: string]: any | any[]
+}


### PR DESCRIPTION
- Switch from btoa to Buffer when encoding basic auth header
- Include FUME version in response to root GET (healthcheck)
- Stronger typing for FHIR resources
- Proper signature and type checking in $reference()