### PR TITLE
Increase request body size limits in server constructor

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -48,9 +48,9 @@ export class FumeServer<ConfigType extends IConfig> implements IFumeServer<Confi
 
   constructor () {
     this.app = express();
-    this.app.use(express.urlencoded({ extended: true, limit: '50mb' }));
-    this.app.use(express.json({ limit: '50mb', type: ['application/json', 'application/fhir+json'] }));
-    this.app.use(express.text({ limit: '50mb', type: ['text/plain', 'application/vnd.outburn.fume', 'x-application/hl7-v2+er7', 'text/csv', 'application/xml'] }));
+    this.app.use(express.urlencoded({ extended: true, limit: '400mb' }));
+    this.app.use(express.json({ limit: '400mb', type: ['application/json', 'application/fhir+json'] }));
+    this.app.use(express.text({ limit: '400mb', type: ['text/plain', 'application/vnd.outburn.fume', 'x-application/hl7-v2+er7', 'text/csv', 'application/xml'] }));
     this.app.use(cors());
   }
 


### PR DESCRIPTION
This PR increases the request body size limits from the default values to 400mb for urlencoded, json, and text content types in the Express.js server constructor.  
This change allows the server to handle larger payloads, which is important for processing large FHIR resources and data files.