### PR TITLE
feat: export native fhir functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 import config from './config';
 import { getAliasResource, getFhirPackageIndex } from './helpers/conformance';
+import fhirFuncs from './helpers/fhirFunctions';
 import { parseCsv } from './helpers/inputConverters';
 import { v2json } from './helpers/inputConverters/hl7v2';
 import expressions from './helpers/jsonataExpression';
@@ -46,5 +47,10 @@ export const fumeUtils = {
   toJsonataString: parser.toJsonataString,
   getSnapshot: parser.getSnapshot,
   v2json,
-  getFhirPackageIndex
+  getFhirPackageIndex,
+  // FHIR functions
+  search: fhirFuncs.search,
+  resolve: fhirFuncs.resolve,
+  literal: fhirFuncs.literal,
+  searchSingle: fhirFuncs.searchSingle
 };


### PR DESCRIPTION
This for tools using FUME as a module to have access to some of the internal stateful functions directly (outside of the context of a mapping expression)