### PR TITLE
Implement standardized error handling with FumeError type

### DIFF
--- a/src/controllers/mapping.ts
+++ b/src/controllers/mapping.ts
@@ -10,6 +10,7 @@ import { convertInputToJson } from '../helpers/inputConverters';
 import { pretty } from '../helpers/jsonataFunctions';
 import { getLogger } from '../helpers/logger';
 import { toJsonataString } from '../helpers/parser/toJsonataString';
+import { createFumeError } from '../types';
 
 const get = async (req: Request, res: Response) => {
   const logger = getLogger();
@@ -50,9 +51,10 @@ const transform = async (req: Request, res: Response) => {
       logger.error(`Mapping '${mappingId}' not found!`);
       res.status(404).json({ message: 'not found' });
     }
-  } catch (error) {
+  } catch (error: any) {
     logger.error({ error });
-    res.status(500).json({ message: error });
+    const fumeError = createFumeError(error);
+    res.status(422).json(fumeError);
   }
 };
 

--- a/src/controllers/root.ts
+++ b/src/controllers/root.ts
@@ -13,6 +13,7 @@ import { convertInputToJson } from '../helpers/inputConverters';
 import { pretty, transform } from '../helpers/jsonataFunctions';
 import { getLogger } from '../helpers/logger';
 import { toJsonataString } from '../helpers/parser/toJsonataString';
+import { createFumeError } from '../types';
 
 const get = async (req: Request, res: Response) => {
   return res.status(200).json(
@@ -28,17 +29,9 @@ const evaluate = async (req: Request, res: Response) => {
     const response = await transform(inputJson, req.body.fume, extraBindings);
     return res.status(200).json(response);
   } catch (error: any) {
-    const data = {
-      __isFumeError: true,
-      message: error.message ?? '',
-      code: error.code ?? '',
-      name: error.name ?? '',
-      token: error.token ?? '',
-      cause: error.cause ?? '',
-      position: error.position ?? ''
-    };
     getLogger().error({ error });
-    return res.status(422).json(data);
+    const fumeError = createFumeError(error);
+    return res.status(422).json(fumeError);
   }
 };
 

--- a/src/types/FumeError.ts
+++ b/src/types/FumeError.ts
@@ -7,4 +7,24 @@ import { JsonataError } from 'jsonata';
 
 export type FumeError = JsonataError & {
   __isFumeError: true
+  message: string
+  name: string
+  cause: string
+};
+
+/**
+ * Factory function to create a FumeError object from any error type
+ * @param error - Any error object or unknown type
+ * @returns A properly formatted FumeError object
+ */
+export const createFumeError = (error: any): FumeError => {
+  return {
+    __isFumeError: true,
+    message: error?.message ?? '',
+    code: error?.code ?? '',
+    name: error?.name ?? '',
+    token: error?.token ?? '',
+    cause: error?.cause ?? '',
+    position: error?.position ?? ''
+  };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,5 +5,7 @@
 export type { ICache } from './Cache';
 export type { IConfig } from './Config';
 export type { IFhirClient } from './FhirClient';
+export type { FumeError } from './FumeError';
+export { createFumeError } from './FumeError';
 export type { IAppBinding, ICacheClass, IFumeServer } from './FumeServer';
 export type { ILogger } from './Logger';


### PR DESCRIPTION
- Add FumeError type extending JsonataError with standardized fields
- Create createFumeError factory function for consistent error formatting
- Export FumeError types and factory from types module
- Update root controller to use createFumeError instead of inline error object
- Update mapping controller to use createFumeError and proper error typing
- Standardize error responses with 422 status code for processing errors