### PR TITLE
Trigger docker publish on release event

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,11 +1,10 @@
 name: Build Docker and Push
 
 on:
-  workflow_run:
-    workflows:
-      - PR workflow
-    types:
-      - completed
+  # Trigger automatically only after semantic-release has finished and published the GitHub Release
+  release:
+    types: [published]
+  # Allow manual runs
   workflow_dispatch:
 
 env:
@@ -13,28 +12,37 @@ env:
 
 jobs:
   deploy:
-    # Only run automatically when the triggering workflow (PR workflow) succeeded.
-    # Allow manual dispatch to always run regardless of prior workflow status.
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    # Run for manual dispatch or a published release
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: 'main'
+          # Use the release tag commit when triggered by a release; fallback to main for manual dispatch.
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || 'main' }}
+          # Fetch full history just in case future steps need tags/commits.
+          fetch-depth: 0
 
       - name: login to docker registry
         uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKERHUB_USERNAME}}
           password: ${{secrets.DOCKER_HUB_TOKEN}}
-          
-      - name: Get Version
+
+      - name: Determine release version
         id: get_version
         run: |
-          RELEASE_VERSION=$(jq -r '.version' package.json)
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
-        
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            # Strip leading v if present (semantic-release default)
+            VERSION="${VERSION#v}"
+          else
+            VERSION=$(jq -r '.version' package.json)
+          fi
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Resolved release version: $VERSION"
+
       - name: Build Docker image
         run: |
           docker build --tag "$DOCKER_IMAGE_NAME:$RELEASE_VERSION" .


### PR DESCRIPTION
This PR updates the Docker build and push workflow to trigger on GitHub release events instead of workflow runs. The workflow now automatically builds and publishes Docker images when semantic-release creates a new GitHub release, while still allowing manual dispatch.

## Key changes:

* Changed trigger from workflow_run (PR workflow completion) to release (published releases)
* Updated version determination logic to extract version from release tag name when triggered by a release event
* Modified checkout to use the release tag commit with full history fetch