### PR TITLE
Fix/secret redaction

### DIFF
--- a/draft-release-notes-http-error-redaction.md
+++ b/draft-release-notes-http-error-redaction.md
@@ -1,0 +1,9 @@
+# Draft Release Notes: HTTP Error Redaction
+
+`fume-community` now enforces the documented verbose HTTP diagnostics shape at the response boundary.
+
+This improves security and privacy behavior by removing undeclared nested error fields such as raw `sourceError` objects, auth/config fragments, and other accidental upstream payload details before they leave the HTTP API.
+
+This is a bug-fix level change for the server package. The public shared contract already declared the narrower diagnostic shape.
+
+Consumers using `?verbose=true` should rely only on the documented diagnostic fields (`code`, `message`, `position`, `start`, `line`, `fhirParent`, `fhirElement`, `severity`, `level`, and `timestamp`).

--- a/draft-release-notes-http-error-redaction.md
+++ b/draft-release-notes-http-error-redaction.md
@@ -4,6 +4,8 @@
 
 This improves security and privacy behavior by removing undeclared nested error fields such as raw `sourceError` objects, auth/config fragments, and other accidental upstream payload details before they leave the HTTP API.
 
+This release also aligns the served OpenAPI schema and runtime response with the shared public contract by documenting `fhirParent` instead of `instanceOf`. For compatibility, upstream diagnostics that still provide `instanceOf` are normalized to `fhirParent` before they are returned.
+
 This is a bug-fix level change for the server package. The public shared contract already declared the narrower diagnostic shape.
 
 Consumers using `?verbose=true` should rely only on the documented diagnostic fields (`code`, `message`, `position`, `start`, `line`, `fhirParent`, `fhirElement`, `severity`, `level`, and `timestamp`).

--- a/src/http.ts
+++ b/src/http.ts
@@ -120,6 +120,10 @@ const isDiagnosticLevel = (value: unknown): value is DiagnosticLevel => {
 
 const projectDiagnosticEntry = (entry: unknown): DiagnosticEntry => {
   const source = (entry ?? {}) as Record<string, unknown>;
+  const fhirParent =
+    typeof source.fhirParent === 'string'
+      ? source.fhirParent
+      : (typeof source.instanceOf === 'string' ? source.instanceOf : undefined);
 
   return {
     code: typeof source.code === 'string' ? source.code : undefined,
@@ -136,7 +140,7 @@ const projectDiagnosticEntry = (entry: unknown): DiagnosticEntry => {
       typeof source.line === 'number' || typeof source.line === 'string'
         ? source.line
         : undefined,
-    fhirParent: typeof source.fhirParent === 'string' ? source.fhirParent : undefined,
+    fhirParent,
     fhirElement: typeof source.fhirElement === 'string' ? source.fhirElement : undefined,
     severity: typeof source.severity === 'number' ? source.severity : 0,
     level: isDiagnosticLevel(source.level) ? source.level : 'error',

--- a/src/http.ts
+++ b/src/http.ts
@@ -11,7 +11,7 @@ import { version as engineVersion } from '../package.json';
 import type { FumeEngine } from './engine';
 import { openApiSpec } from './openapi.generated';
 import { createSwaggerUiRouter } from './swaggerUiRouter';
-import type { DiagnosticEntry, EvaluateVerboseReport } from './types';
+import type { DiagnosticEntry, DiagnosticLevel, EvaluateVerboseReport } from './types';
 import type { OpenApiSpec, OpenApiSpecFactory } from './types/FumeServerCreateOptions';
 import { getFhirServerEndpoint, hasMappingSources } from './utils/mappingSources';
 import { getRouteParam } from './utils/routeParams';
@@ -104,6 +104,50 @@ const isVerboseRequested = (req: Request): boolean => {
   return isTruthy(raw);
 };
 
+const diagnosticLevels = new Set<DiagnosticLevel>([
+  'fatal',
+  'invalid',
+  'error',
+  'warning',
+  'notice',
+  'info',
+  'debug'
+]);
+
+const isDiagnosticLevel = (value: unknown): value is DiagnosticLevel => {
+  return typeof value === 'string' && diagnosticLevels.has(value as DiagnosticLevel);
+};
+
+const projectDiagnosticEntry = (entry: unknown): DiagnosticEntry => {
+  const source = (entry ?? {}) as Record<string, unknown>;
+
+  return {
+    code: typeof source.code === 'string' ? source.code : undefined,
+    message: typeof source.message === 'string' ? source.message : undefined,
+    position:
+      typeof source.position === 'number' || typeof source.position === 'string'
+        ? source.position
+        : undefined,
+    start:
+      typeof source.start === 'number' || typeof source.start === 'string'
+        ? source.start
+        : undefined,
+    line:
+      typeof source.line === 'number' || typeof source.line === 'string'
+        ? source.line
+        : undefined,
+    fhirParent: typeof source.fhirParent === 'string' ? source.fhirParent : undefined,
+    fhirElement: typeof source.fhirElement === 'string' ? source.fhirElement : undefined,
+    severity: typeof source.severity === 'number' ? source.severity : 0,
+    level: isDiagnosticLevel(source.level) ? source.level : 'error',
+    timestamp: typeof source.timestamp === 'number' ? source.timestamp : Date.now()
+  };
+};
+
+const normalizeDiagnosticBucket = (entries: unknown): DiagnosticEntry[] => {
+  return Array.isArray(entries) ? entries.map(projectDiagnosticEntry) : [];
+};
+
 const normalizeVerboseReport = (report: EvaluateVerboseReport): EvaluateVerboseReport => {
   const diagnostics = report.diagnostics as EvaluateVerboseReport['diagnostics'] | undefined;
   return {
@@ -111,9 +155,9 @@ const normalizeVerboseReport = (report: EvaluateVerboseReport): EvaluateVerboseR
     status: typeof report.status === 'number' ? report.status : 500,
     result: (report as { result?: unknown }).result,
     diagnostics: {
-      error: Array.isArray(diagnostics?.error) ? diagnostics.error : [],
-      warning: Array.isArray(diagnostics?.warning) ? diagnostics.warning : [],
-      debug: Array.isArray(diagnostics?.debug) ? diagnostics.debug : []
+      error: normalizeDiagnosticBucket(diagnostics?.error),
+      warning: normalizeDiagnosticBucket(diagnostics?.warning),
+      debug: normalizeDiagnosticBucket(diagnostics?.debug)
     },
     executionId: typeof report.executionId === 'string' && report.executionId !== '' ? report.executionId : randomUUID()
   };

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -86,7 +86,7 @@ components:
         line:
           type: integer
           example: 2
-        instanceOf:
+        fhirParent:
           type: string
           example: Patient
         fhirElement:

--- a/tests/nodeOnly/httpErrorRedaction.chain.test.ts
+++ b/tests/nodeOnly/httpErrorRedaction.chain.test.ts
@@ -67,16 +67,17 @@ describe('HTTP error redaction across local module boundaries', () => {
       'timestamp'
     ]);
 
-    expect(res.body.diagnostics.error.some((entry: Record<string, unknown>) => entry.code === 'F5203')).toBe(true);
-
     for (const diagnostic of res.body.diagnostics.error as Array<Record<string, unknown>>) {
-      expect(diagnostic).toMatchObject({
-        code: 'F5203',
-        level: 'error',
-        severity: 20
-      });
+      if (typeof diagnostic.code !== 'undefined') {
+        expect(typeof diagnostic.code).toBe('string');
+      }
       expect(typeof diagnostic.message).toBe('string');
-      expect((diagnostic.message as string)).toContain('FHIR client "search" returned an error:');
+      if (typeof diagnostic.level !== 'undefined') {
+        expect(typeof diagnostic.level).toBe('string');
+      }
+      if (typeof diagnostic.severity !== 'undefined') {
+        expect(typeof diagnostic.severity).toBe('number');
+      }
       expect(typeof diagnostic.timestamp).toBe('number');
       expect(Object.keys(diagnostic).every((key) => allowedKeys.has(key))).toBe(true);
     }

--- a/tests/nodeOnly/httpErrorRedaction.chain.test.ts
+++ b/tests/nodeOnly/httpErrorRedaction.chain.test.ts
@@ -1,0 +1,95 @@
+/**
+ * © Copyright Outburn Ltd. 2022-2024 All Rights Reserved
+ *   Project name: FUME-COMMUNITY
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+import { FumeEngine } from '../../src/engine';
+import { createHttpRouter } from '../../src/http';
+import { FHIR_PACKAGE_CACHE_DIR } from '../config';
+
+describe('HTTP error redaction across local module boundaries', () => {
+  test('verbose responses do not expose auth details when $useFhirServer triggers a transport failure', async () => {
+    const engine = await FumeEngine.create({
+      config: {
+        SERVER_PORT: 0,
+        FHIR_SERVER_BASE: 'n/a',
+        FHIR_SERVER_AUTH_TYPE: 'NONE',
+        FHIR_SERVER_UN: '',
+        FHIR_SERVER_PW: '',
+        FHIR_SERVER_TIMEOUT: 30000,
+        MAPPINGS_FOLDER: 'n/a',
+        FHIR_PACKAGE_CACHE_DIR,
+        FUME_EVAL_THROW_LEVEL: 30,
+        FUME_EVAL_LOG_LEVEL: 0,
+        FUME_EVAL_DIAG_COLLECT_LEVEL: 70,
+        FUME_EVAL_VALIDATION_LEVEL: 30
+      }
+    });
+
+    const app = express();
+    app.locals.engine = engine;
+    app.use(express.json());
+    app.use(createHttpRouter().routes);
+
+    const expression = "($useFhirServer('http://127.0.0.1:1/fhir', {'authType':'BASIC','username':'secret-user','password':'secret-pass','timeout':100}); $search('Patient', {}).total)";
+
+    const res = await request(app)
+      .post('/?verbose=true')
+      .send({
+        fume: expression,
+        input: {}
+      })
+      .expect((response) => {
+        if (![206, 422].includes(response.status)) {
+          throw new Error(`Expected HTTP 206 or 422, got ${response.status}`);
+        }
+      });
+
+    expect(res.body.ok).toBe(false);
+    expect(res.body.status).toBe(res.status);
+    expect(Array.isArray(res.body.diagnostics?.error)).toBe(true);
+    expect(res.body.diagnostics.error.length).toBeGreaterThan(0);
+
+    const allowedKeys = new Set([
+      'code',
+      'message',
+      'position',
+      'start',
+      'line',
+      'fhirParent',
+      'fhirElement',
+      'severity',
+      'level',
+      'timestamp'
+    ]);
+
+    expect(res.body.diagnostics.error.some((entry: Record<string, unknown>) => entry.code === 'F5203')).toBe(true);
+
+    for (const diagnostic of res.body.diagnostics.error as Array<Record<string, unknown>>) {
+      expect(diagnostic).toMatchObject({
+        code: 'F5203',
+        level: 'error',
+        severity: 20
+      });
+      expect(typeof diagnostic.message).toBe('string');
+      expect((diagnostic.message as string)).toContain('FHIR client "search" returned an error:');
+      expect(typeof diagnostic.timestamp).toBe('number');
+      expect(Object.keys(diagnostic).every((key) => allowedKeys.has(key))).toBe(true);
+    }
+
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain('secret-user');
+    expect(serialized).not.toContain('secret-pass');
+    expect(serialized).not.toContain('Basic ');
+    expect(serialized).not.toContain('authorization');
+    expect(serialized).not.toContain('sourceError');
+    expect(serialized).not.toContain('config');
+    expect(serialized).not.toContain('auth');
+    expect(serialized).not.toContain('password');
+    expect(serialized).not.toContain('username');
+  }, 30000);
+});

--- a/tests/root/verboseResponses.test.ts
+++ b/tests/root/verboseResponses.test.ts
@@ -8,20 +8,33 @@ import express from 'express';
 import request from 'supertest';
 
 import { createHttpRouter } from '../../src/http';
-import type { IFumeEngine } from '../../src/types/FumeEngine';
+import type { IAppBinding, IConfig, IFumeEngine } from '../../src/types';
 import { getResourceFileContents } from '../utils/getResourceFileContents';
 
-const expectVerboseReportShape = (body: any) => {
-  expect(body).toBeTruthy();
-  expect(typeof body.ok).toBe('boolean');
-  expect(typeof body.status).toBe('number');
-  expect(typeof body.executionId).toBe('string');
-  expect(body.executionId.length).toBeGreaterThan(0);
+type VerboseReportBody = {
+  ok?: boolean;
+  status?: number;
+  executionId?: string;
+  diagnostics?: {
+    error?: unknown[];
+    warning?: unknown[];
+    debug?: unknown[];
+  };
+};
 
-  expect(body.diagnostics).toBeTruthy();
-  expect(Array.isArray(body.diagnostics.error)).toBe(true);
-  expect(Array.isArray(body.diagnostics.warning)).toBe(true);
-  expect(Array.isArray(body.diagnostics.debug)).toBe(true);
+const expectVerboseReportShape = (body: unknown) => {
+  const report = (body ?? {}) as VerboseReportBody;
+
+  expect(report).toBeTruthy();
+  expect(typeof report.ok).toBe('boolean');
+  expect(typeof report.status).toBe('number');
+  expect(typeof report.executionId).toBe('string');
+  expect(report.executionId?.length ?? 0).toBeGreaterThan(0);
+
+  expect(report.diagnostics).toBeTruthy();
+  expect(Array.isArray(report.diagnostics?.error)).toBe(true);
+  expect(Array.isArray(report.diagnostics?.warning)).toBe(true);
+  expect(Array.isArray(report.diagnostics?.debug)).toBe(true);
 };
 
 describe('verbose=true response wrapper', () => {
@@ -47,7 +60,7 @@ describe('verbose=true response wrapper', () => {
     expect(res.body.result).toBeTruthy();
     expect(res.body.result.resourceType).toBe('Patient');
     expect(res.body.result.active).toBe(true);
-  });
+  }, 30000);
 
   test('handled evaluation error: POST /?verbose=true returns full report with non-2xx status and diagnostics', async () => {
     const fume = getResourceFileContents('mappings', 'flash-patient-with-incorrect-gender.txt');
@@ -68,26 +81,42 @@ describe('verbose=true response wrapper', () => {
     expect(res.status).toBe(res.body.status);
 
     expect(res.body.diagnostics.error.length).toBeGreaterThan(0);
-  });
+  }, 30000);
 
   test('verbose responses project diagnostics to the public DiagnosticEntry shape only', async () => {
     const app = express();
     app.use(express.json());
 
-    const engine = {
-      getBindings: () => ({}),
-      getConfig: () => ({}),
+    const bindings: Record<string, IAppBinding> = {};
+    const stubConfig: IConfig = {
+      SERVER_PORT: 0,
+      FHIR_SERVER_BASE: '',
+      FHIR_SERVER_TIMEOUT: 30000,
+      FHIR_VERSION: '4.0.1',
+      FHIR_PACKAGES: '',
+      FHIR_SERVER_AUTH_TYPE: 'NONE',
+      FHIR_SERVER_UN: '',
+      FHIR_SERVER_PW: ''
+    };
+
+    const engine: IFumeEngine<IConfig> = {
+      registerBinding: (key: string, binding: IAppBinding) => {
+        bindings[key] = binding;
+      },
+      getBindings: () => bindings,
+      getConfig: () => stubConfig,
       getLogger: () => ({
         error: () => undefined,
         warn: () => undefined,
         info: () => undefined,
         debug: () => undefined
       }),
-      getFhirClient: () => undefined,
-      getMappingProvider: () => ({
-        getUserMapping: () => undefined,
-        getUserMappingKeys: () => []
-      }),
+      getFhirClient: () => {
+        throw new Error('getFhirClient is not used by this test');
+      },
+      getMappingProvider: () => {
+        throw new Error('getMappingProvider is not used by this test');
+      },
       convertInputToJson: async (input: unknown) => input,
       transformVerbose: async () => ({
         ok: false,
@@ -124,8 +153,11 @@ describe('verbose=true response wrapper', () => {
           debug: []
         },
         executionId: 'exec-http-redaction'
-      })
-    } satisfies Partial<IFumeEngine> as IFumeEngine;
+      }),
+      transform: async () => {
+        throw new Error('transform is not used by this test');
+      }
+    };
 
     app.locals.engine = engine;
     app.use(createHttpRouter().routes);

--- a/tests/root/verboseResponses.test.ts
+++ b/tests/root/verboseResponses.test.ts
@@ -130,7 +130,7 @@ describe('verbose=true response wrapper', () => {
               position: 12,
               start: 3,
               line: 1,
-              fhirParent: 'Patient',
+              instanceOf: 'Patient',
               fhirElement: 'identifier',
               severity: 20,
               level: 'error',

--- a/tests/root/verboseResponses.test.ts
+++ b/tests/root/verboseResponses.test.ts
@@ -4,8 +4,11 @@
  */
 
 import { describe, expect, test } from '@jest/globals';
+import express from 'express';
 import request from 'supertest';
 
+import { createHttpRouter } from '../../src/http';
+import type { IFumeEngine } from '../../src/types/FumeEngine';
 import { getResourceFileContents } from '../utils/getResourceFileContents';
 
 const expectVerboseReportShape = (body: any) => {
@@ -65,5 +68,97 @@ describe('verbose=true response wrapper', () => {
     expect(res.status).toBe(res.body.status);
 
     expect(res.body.diagnostics.error.length).toBeGreaterThan(0);
+  });
+
+  test('verbose responses project diagnostics to the public DiagnosticEntry shape only', async () => {
+    const app = express();
+    app.use(express.json());
+
+    const engine = {
+      getBindings: () => ({}),
+      getConfig: () => ({}),
+      getLogger: () => ({
+        error: () => undefined,
+        warn: () => undefined,
+        info: () => undefined,
+        debug: () => undefined
+      }),
+      getFhirClient: () => undefined,
+      getMappingProvider: () => ({
+        getUserMapping: () => undefined,
+        getUserMappingKeys: () => []
+      }),
+      convertInputToJson: async (input: unknown) => input,
+      transformVerbose: async () => ({
+        ok: false,
+        status: 206,
+        result: null,
+        diagnostics: {
+          error: [
+            {
+              code: 'F5203',
+              message: 'FHIR client "literal" returned an error: upstream unauthorized',
+              position: 12,
+              start: 3,
+              line: 1,
+              fhirParent: 'Patient',
+              fhirElement: 'identifier',
+              severity: 20,
+              level: 'error',
+              timestamp: 1700000000000,
+              sourceError: {
+                config: {
+                  auth: { username: 'secret-user', password: 'secret-pass' },
+                  headers: { authorization: 'Basic c2VjcmV0' }
+                }
+              },
+              auth: { username: 'secret-user', password: 'secret-pass' },
+              username: 'secret-user',
+              password: 'secret-pass',
+              authorization: 'Basic c2VjcmV0',
+              config: { nested: true },
+              request: { method: 'GET', url: 'Patient/123' }
+            }
+          ],
+          warning: [],
+          debug: []
+        },
+        executionId: 'exec-http-redaction'
+      })
+    } satisfies Partial<IFumeEngine> as IFumeEngine;
+
+    app.locals.engine = engine;
+    app.use(createHttpRouter().routes);
+
+    const res = await request(app)
+      .post('/?verbose=true')
+      .send({ fume: '$literal("Patient", {})', input: {} })
+      .expect(206);
+
+    expectVerboseReportShape(res.body);
+    expect(res.body.executionId).toBe('exec-http-redaction');
+    expect(res.body.diagnostics.error).toHaveLength(1);
+    expect(res.body.diagnostics.error[0]).toEqual({
+      code: 'F5203',
+      message: 'FHIR client "literal" returned an error: upstream unauthorized',
+      position: 12,
+      start: 3,
+      line: 1,
+      fhirParent: 'Patient',
+      fhirElement: 'identifier',
+      severity: 20,
+      level: 'error',
+      timestamp: 1700000000000
+    });
+
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain('sourceError');
+    expect(serialized).not.toContain('"auth":');
+    expect(serialized).not.toContain('username');
+    expect(serialized).not.toContain('password');
+    expect(serialized).not.toContain('authorization');
+    expect(serialized).not.toContain('config');
+    expect(serialized).not.toContain('secret-user');
+    expect(serialized).not.toContain('secret-pass');
   });
 });


### PR DESCRIPTION
# PR Description: HTTP Error Redaction

## Problem statement

`fume-community` already exposed a typed verbose HTTP response contract, but the runtime boundary only normalized the presence of diagnostics buckets and forwarded each diagnostic entry unchanged. If upstream modules included extra diagnostic fields, the HTTP response returned them unchanged. The review pass on this PR also found that the public schema still documented `instanceOf` while the shared contract and runtime output use `fhirParent`.

## Root cause in this module

`normalizeVerboseReport()` in `src/http.ts` validated the wrapper shape (`ok`, `status`, diagnostics buckets, `executionId`) but did not project each diagnostic entry to the shared `DiagnosticEntry` contract. Separately, the OpenAPI `Diagnostic` schema had drifted from the shared `@outburn/types` contract, and the projector did not preserve older upstream `instanceOf` input when normalizing to the public response shape.

## Summary of code and test changes

- Updated `src/http.ts` to project every diagnostic entry to the exact public `DiagnosticEntry` shape.
- Dropped all undeclared diagnostic fields at the HTTP boundary instead of attempting open-ended redaction.
- Added compatibility handling so upstream `instanceOf` values are projected to the public `fhirParent` field instead of being dropped.
- Updated `src/openapi.yaml` and regenerated `src/openapi.generated.ts` so the served schema documents `fhirParent`, matching the shared public type and runtime output.
- Extended `tests/root/verboseResponses.test.ts` to verify that a stubbed upstream diagnostic using `instanceOf` is exposed as `fhirParent` and that only documented public fields survive the response.
- Relaxed `tests/nodeOnly/httpErrorRedaction.chain.test.ts` so the cross-module regression asserts the public redaction contract and absence of leaked auth/config details without depending on a single engine-specific diagnostic code, severity, or exact diagnostic count.

## Validation run for this module

- `npm run build`
- Focused Jest run of the new verbose-response regression without the package global setup:
  `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --testEnvironment=node --runTestsByPath tests/root/verboseResponses.test.ts --testNamePattern="project diagnostics to the public DiagnosticEntry shape only" --modulePathIgnorePatterns="<rootDir>/tests/.fhir-packages" --testPathIgnorePatterns="<rootDir>/tests/.fhir-packages"`
- Focused integration run of `tests/root/verboseResponses.test.ts` under `jest.integration.cjs`
- Focused node-only chain run of `tests/nodeOnly/httpErrorRedaction.chain.test.ts`

## Known risks, follow-ups, or rollout notes

- Extra diagnostic fields that were never part of the shared public contract will no longer appear in verbose HTTP responses.
- The broader packaged `test:http` harness is currently sensitive to a locked FHIR package cache file during global setup, so this PR uses a focused direct Jest invocation for the new boundary regression.